### PR TITLE
add p2wpkh-p2sh (ypub), p2wpkh (zpub) support

### DIFF
--- a/bip32/bip32.py
+++ b/bip32/bip32.py
@@ -182,13 +182,17 @@ class BIP32:
         """
         return self.get_extended_pubkey_from_path(path)[1]
 
-    def get_xpriv_from_path(self, path):
+    def get_xpriv_from_path(self, path, script="p2pkh"):
         """Get an encoded extended privkey from a derivation path.
 
         :param path: A list of integers (index of each depth) or a string with
                      m/x/x'/x notation. (e.g. m/0'/1/2'/2 or m/0H/1/2H/2).
+        :param script: Can be "p2pkh" (legacy, xpub), "p2wpkh-p2sh" (ypub),
+                       "p2wpkh" (zpub). Defaults to "p2pkh".
         :return: The encoded extended pubkey as str.
         """
+        assert script in ["p2pkh", "p2wpkh-p2sh", "p2wpkh"]
+
         if self.privkey is None:
             raise PrivateDerivationError
 
@@ -208,18 +212,22 @@ class BIP32:
             parent_pubkey,
             path[-1],
             chaincode,
-            self.network,
+            "main-"+script if script != "p2pkh" and script else self.network,
         )
 
         return base58.b58encode_check(extended_key).decode()
 
-    def get_xpub_from_path(self, path):
+    def get_xpub_from_path(self, path, script="p2pkh"):
         """Get an encoded extended pubkey from a derivation path.
 
         :param path: A list of integers (index of each depth) or a string with
                      m/x/x'/x notation. (e.g. m/0'/1/2'/2 or m/0H/1/2H/2).
+        :param script: Can be "p2pkh" (legacy, xpub), "p2wpkh-p2sh" (ypub),
+                       "p2wpkh" (zpub). Defaults to "p2pkh".
         :return: The encoded extended pubkey as str.
         """
+        assert script in ["p2pkh", "p2wpkh-p2sh", "p2wpkh"]
+
         if isinstance(path, str):
             path = _deriv_path_str_to_list(path)
 
@@ -239,7 +247,7 @@ class BIP32:
             parent_pubkey,
             path[-1],
             chaincode,
-            self.network,
+            "main-"+script if script != "p2pkh" and script else self.network,
         )
 
         return base58.b58encode_check(extended_key).decode()

--- a/bip32/utils.py
+++ b/bip32/utils.py
@@ -8,8 +8,16 @@ REGEX_DERIVATION_PATH = re.compile("^m(/[0-9]+['hH]?)*$")
 HARDENED_INDEX = 0x80000000
 ENCODING_PREFIX = {
     "main": {
-        "private": 0x0488ADE4,
+        "private": 0x0488ADE4, # xpub/xprv
         "public": 0x0488B21E,
+    },
+    "main-p2wpkh-p2sh": { # ypub/yprv
+        "private": 0x049d7878,
+        "public": 0x049d7cb2,
+    },
+    "main-p2wpkh": {
+        "private": 0x04b2430c, # zpub/zprv (bech32)
+        "public": 0x04b24746,
     },
     "test": {
         "private": 0x04358394,


### PR DESCRIPTION
I needed to create ypub and zpub extended keys, so I made this small modification.
note: if this doesn't get accepted, for future readers, you can use this instead:
`base58.b58encode_check(base58.b58decode_check(xpub_here).replace(0x0488B21E.to_bytes(4, "big"), 0x04b24746.to_bytes(4, "big"))).decode()`