### PR TITLE
Add methods get_xpub_bytes and get_xpriv_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ include an index `>= HARDENED_INDEX`.
 
 Equivalent to `get_xpriv_from_path([])`.
 
+### get_xpriv_bytes(path)
+
+Equivalent to `get_xpriv([])`, but not serialized in base58
+
 ### get_xpub(path)
 
 Equivalent to `get_xpub_from_path([])`.
+
+### get_xpub_bytes(path)
+
+Equivalent to `get_xpub([])`, but not serialized in base58

--- a/bip32/bip32.py
+++ b/bip32/bip32.py
@@ -245,10 +245,14 @@ class BIP32:
         return base58.b58encode_check(extended_key).decode()
 
     def get_xpriv(self):
+        """Get the base58 encoded extended private key."""
+        return base58.b58encode_check(self.get_xpriv_bytes()).decode()
+
+    def get_xpriv_bytes(self):
         """Get the encoded extended private key."""
         if self.privkey is None:
             raise PrivateDerivationError
-        extended_key = _serialize_extended_key(
+        return _serialize_extended_key(
             self.privkey,
             self.depth,
             self.parent_fingerprint,
@@ -256,11 +260,14 @@ class BIP32:
             self.chaincode,
             self.network,
         )
-        return base58.b58encode_check(extended_key).decode()
 
     def get_xpub(self):
         """Get the encoded extended public key."""
-        extended_key = _serialize_extended_key(
+        return base58.b58encode_check(self.get_xpub_bytes()).decode()
+
+    def get_xpub_bytes(self):
+        """Get the encoded extended public key."""
+        return _serialize_extended_key(
             self.pubkey,
             self.depth,
             self.parent_fingerprint,
@@ -268,7 +275,6 @@ class BIP32:
             self.chaincode,
             self.network,
         )
-        return base58.b58encode_check(extended_key).decode()
 
     @classmethod
     def from_xpriv(cls, xpriv):

--- a/tests/test_bip32.py
+++ b/tests/test_bip32.py
@@ -13,9 +13,15 @@ def test_vector_1():
         bip32.get_xpub()
         == "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
     )
+    assert bip32.get_xpub_bytes() == bytes.fromhex(
+        "0488b21e000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d5080339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2"
+    )
     assert (
         bip32.get_xpriv()
         == "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    )
+    assert bip32.get_xpriv_bytes() == bytes.fromhex(
+        "0488ade4000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d50800e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35"
     )
     # Chain m/0H
     assert (
@@ -112,9 +118,15 @@ def test_vector_2():
         bip32.get_xpub()
         == "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
     )
+    assert bip32.get_xpub_bytes() == bytes.fromhex(
+        "0488b21e00000000000000000060499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd968903cbcaa9c98c877a26977d00825c956a238e8dddfbd322cce4f74b0b5bd6ace4a7"
+    )
     assert (
         bip32.get_xpriv()
         == "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
+    )
+    assert bip32.get_xpriv_bytes() == bytes.fromhex(
+        "0488ade400000000000000000060499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd9689004b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e"
     )
     # Chain m/0
     assert (


### PR DESCRIPTION
Methods for returning the xpubs/xprivs in bytes, as specified in the
BIP32 spec.
Since the spec doesn't include bytes test vectors, I serialized them
manually using rust-bitcoin and then checked that this library would
serialize them in the same way.