### PR TITLE
Bump coincurve and release version 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.4
+
+- Support Coincurve up to version 18. This version includes support for BIP340 x-only keys and
+  Schnorr signatures.
+
+
 # 3.3
 
 - Implement a pure Python fallback for RIPEMD160 in case `hashlib` does not provide it.

--- a/bip32/__init__.py
+++ b/bip32/__init__.py
@@ -1,7 +1,7 @@
 from .bip32 import BIP32, PrivateDerivationError, InvalidInputError
 from .utils import BIP32DerivationError, HARDENED_INDEX
 
-__version__ = "3.3"
+__version__ = "3.4"
 
 __all__ = [
     "BIP32",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-coincurve>=15.0,<18
+coincurve>=15.0,<19
 base58~=2.0


### PR DESCRIPTION
To make BIP340 x-only keys and Schnorr signatures available downstream.