### PR TITLE
Release 4.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,7 +57,7 @@ jobs:
   coincurve_versions:
     strategy:
       matrix:
-        coincurve-version: [15, 16, 17]
+        coincurve-version: [15, 16, 17, 18, '19.0.1', 20]
 
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 4.0
+
+This is a breaking release.
+
+- Drop support for Python 3.7.
+- Support Coincurve up to version 20.
+- Drop base58 dependency. Port base58 code directly in-tree as a `base58` module.
+- Fix circular dependency in source installation.
+- A new method `get_fingerprint()` was added.
+
+
 # 3.4
 
 - Support Coincurve up to version 18. This version includes support for BIP340 x-only keys and

--- a/bip32/__init__.py
+++ b/bip32/__init__.py
@@ -1,7 +1,7 @@
 from .bip32 import BIP32, PrivateDerivationError, InvalidInputError
 from .utils import BIP32DerivationError, HARDENED_INDEX
 
-__version__ = "3.4"
+__version__ = "4.0"
 
 __all__ = [
     "BIP32",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-coincurve>=15.0,<19
+coincurve>=15.0,<21


### PR DESCRIPTION
Takes over #40 now that Coincurve appears to be fixed (see https://github.com/ofek/coincurve/issues/133#issuecomment-1974862264). Based on #42.