### PR TITLE
Upgrade `coincurve` versioning to allow 21.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         brew install autoconf automake libffi libtool pkg-config python
         pip install -r requirements.txt
     - name: Install python-bip32 from source
-      run: python setup.py install
+      run: pip install .
     - name: Test with pytest
       run: |
         pip install -r tests/requirements.txt
@@ -72,4 +72,4 @@ jobs:
         pip install setuptools
         pip install -r tests/requirements.txt
         pip install -I coincurve==${{ matrix.coincurve-version }}
-        python setup.py install
+        pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-coincurve>=15.0,<21
+coincurve>=15.0,<22


### PR DESCRIPTION
This upgrades `coincurve` to [v21.0.0](https://github.com/ofek/coincurve/releases/tag/v21.0.0) which brings performance improvements and removes all runtime dependencies!