### PR TITLE
Release 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 5.0
+
+This is a breaking release.
+
+- Migrate project to new `pyproject.toml` standard from `setup.py`/`requirements.txt`.
+- As part of migration, top-level `__version__` variable was dropped from the package.
+- Support for Python 3.8 was dropped due to a breaking change in the way setuptools interpret the license keys in `pyproject.toml`.
+
 # 4.0
 
 This is a breaking release.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This uses [`coincurve`](https://github.com/ofek/coincurve) as a wrapper for [`li
 # From the root of the repository
 python3 -m venv venv
 . venv/bin/activate
-pip install -r requirements.txt && pip install pytest
+pip install -r tests/requirements.txt && pip install pytest
 PYTHONPATH=$PYTHONPATH:$PWD/bip32 pytest -vvv
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bip32"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
     "coincurve>=15.0,<21",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "4.0.0"
 dependencies = [
     "coincurve>=15.0,<21",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "Antoine Poinsot", email = "darosior@protonmail.com"},
 ]


### PR DESCRIPTION
On top of #49, this releases a new version of python-bip32 with only the project structure change (migration to `pyproject.toml`).