### PR TITLE
Release 5.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,7 +50,7 @@ jobs:
   coincurve_versions:
     strategy:
       matrix:
-        coincurve-version: [15, 16, 17, 18, '19.0.1', 20]
+        coincurve-version: [15, 16, 17, 18, '19.0.1', 20, 21]
 
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1
+
+- Support Coincurve up to version 21. This version notably bumps libsecp to version 0.6.0 and gets rid of all runtime dependencies.
+
 # 5.0
 
 This is a breaking release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "bip32"
 version = "5.0.0"
 dependencies = [
-    "coincurve>=15.0,<21",
+    "coincurve>=15.0,<22",
 ]
 requires-python = ">=3.9"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bip32"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
     "coincurve>=15.0,<22",
 ]


### PR DESCRIPTION
To make the Coincurve version bump available.

Depends on #53.